### PR TITLE
use complete git clone url and update renamed dokuwiki repo

### DIFF
--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -55,9 +55,9 @@ class Downloader extends CLI
         if ($options->getOpt('dokuwiki')) {
             $dls[] = [
                 'name' => 'dokuwiki',
-                'url' => 'https://github.com/splitbrain/dokuwiki/archive/master.zip',
+                'url' => 'https://github.com/dokuwiki/dokuwiki/archive/master.zip',
                 'date' => 'master',
-                'repo' => 'https://github.com/splitbrain/dokuwiki',
+                'repo' => 'https://github.com/dokuwiki/dokuwiki.git',
             ];
         }
 


### PR DESCRIPTION
`getDownloads()` does a `normalizedRepo()` and after that the entry for DokuWiki itself is added. Therefore, it not normalized. 

Use complete git clone url instead.
Update renamed references.

Effectively, due to this fix it should retrieve the checkout of git instead of an export of the repository. The export is filtered and does not contain the test classes. This will fix #2 

(not tested)